### PR TITLE
Refactor: index.js format improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
-webext-launch-web-auth-flow
-============
+# webext-launch-web-auth-flow
 
-Polyfill `launchWebAuthFlow` with popups.
+Polyfill `launchWebAuthFlow` with popups or browser tabs.
 
-Installation
-------------
+## Installation
 
 ### Via npm
 
-```
+```bash
 npm install webext-launch-web-auth-flow
 ```
 
 ```js
-const launchWebAuthFlow = require("webext-launch-web-auth-flow");
+import launchWebAuthFlow from "webext-launch-web-auth-flow";
 ```
 
 ### Pre-built dist
 
 You can find it under the `dist` folder, or [download from unpkg](https://unpkg.com/webext-launch-web-auth-flow/dist/).
 
-Why
-----
+## Why
 
 1. Builtin `launchWebAuthFlow` doesn't reuse the browser session. This library does.
 2. Builtin `launchWebAuthFlow` doesn't allow custom redirect_uri. This library does.
 
-Permission
------------
+## Permissions
 
 ```js
 {
+ "background": {
+  ...
+  "persistent": true
+  },
   "permissions": [
     "webRequest",
     "webRequestBlocking",
@@ -42,22 +42,20 @@ Permission
 
 To polyfill `launchWebAuthFlow`, this library uses following API/permissions:
 
-1. `windows` and `tabs` - this library launches a window dialog (or tab in Firefox android) to login.
-2. `webRequest` with `blocking` - this library cancels the request to `redirect_uri` so it won't leak the token/code to `redirect_uri` (or `redirect_uri` is unresolveable e.g. the URL from `identity.getRedirectURL`).
-3. `webNavigation` - the login dialog is minimized unless there is no redirect. It checks the loading state using `webNavigation.onDOMContentLoaded`.
+1. `windows` and `tabs` - this library launches a window dialog (or tab in Firefox android) to login. Most methods from these APIs can be used without explicitly declaring any permissions in the extension's manifest file, therefore there's no need to mention them in the code above.
+2. `webRequest` - this library cannot be used with non-persistent background pages, otherwise you'll get an error. To avoid this, set your background page `persistent` key to `true`.
+3. `webRequestBlocking` this cancels the request to `redirect_uri` so it won't leak the token/code to `redirect_uri` (or `redirect_uri` is unresolveable e.g. the URL from `identity.getRedirectURL`).
+4. `webNavigation` - the login dialog is minimized unless there is no redirect. It checks the loading state using `webNavigation.onDOMContentLoaded`.
 
-Compatibility
---------------
+## Compatibility
 
-This library references the global `browser`. To make it work on Chrome, you need something like [webextension-polyfill](https://github.com/mozilla/webextension-polyfill)
+This library references the `browser` global variable, which is from Firefox. To make it work on Chrome (which uses the `chrome` global variable instead) install [webextension-polyfill](https://github.com/mozilla/webextension-polyfill).
 
-Known issues
--------------
+## Known issues
 
-* Currently there is no good way to create an "inactive minimized dialog" on both Chrome and Firefox. Ref: https://crbug.com/783827 & https://bugzilla.mozilla.org/show_bug.cgi?id=1659190
+- Currently there is no good way to create an "inactive minimized dialog" on both Chrome and Firefox. Ref: <https://crbug.com/783827> & <https://bugzilla.mozilla.org/show_bug.cgi?id=1659190>.
 
-API reference
--------------
+## API reference
 
 This module exports a single function.
 
@@ -68,7 +66,6 @@ launchWebAuthFlow({
   url: String,
   redirect_uri: String,
   interactive?: Boolean = false,
-  
   alwaysUseTab?: Boolean = false,
   windowOptions?: Object
 }) => finalUrl: String
@@ -80,14 +77,11 @@ By default, this library uses a popup to display the login page. If popups are u
 
 Use `windowOptions` to set extra properties that will be sent to [`browser.windows.create`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/create).
 
-Changelog
----------
+## Changelog
 
-* 0.1.1 (Feb 18, 2021)
-
+- 0.1.1 (Feb 18, 2021)
   - Add: `alwaysUseTab` option.
   - Add: `windowOptions` option.
 
-* 0.1.0 (Aug 15, 2020)
-
+- 0.1.0 (Aug 15, 2020)
   - First release.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ npm install webext-launch-web-auth-flow
 ```
 
 ```js
+// With ESM Modules
+import launchWebAuthFlow from "webext-launch-web-auth-flow";
+
+// With CommonJS
+const launchWebAuthFlow = require("webext-launch-web-auth-flow");
+```
+
+```js
 import launchWebAuthFlow from "webext-launch-web-auth-flow";
 ```
 
@@ -43,7 +51,7 @@ You can find it under the `dist` folder, or [download from unpkg](https://unpkg.
 To polyfill `launchWebAuthFlow`, this library uses following API/permissions:
 
 1. `windows` and `tabs` - this library launches a window dialog (or tab in Firefox android) to login. Most methods from these APIs can be used without explicitly declaring any permissions in the extension's manifest file, therefore there's no need to mention them in the code above.
-2. `webRequest` - this library cannot be used with non-persistent background pages, otherwise you'll get an error. To avoid this, set your background page `persistent` key to `true`.
+2. `webRequest` - this library cannot be used with event pages, otherwise you'll get [this error](https://stackoverflow.com/questions/13326105/using-webrequest-api-with-event-page). To avoid it, set your background page `persistent` key to `true`.
 3. `webRequestBlocking` this cancels the request to `redirect_uri` so it won't leak the token/code to `redirect_uri` (or `redirect_uri` is unresolveable e.g. the URL from `identity.getRedirectURL`).
 4. `webNavigation` - the login dialog is minimized unless there is no redirect. It checks the loading state using `webNavigation.onDOMContentLoaded`.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ import launchWebAuthFlow from "webext-launch-web-auth-flow";
 const launchWebAuthFlow = require("webext-launch-web-auth-flow");
 ```
 
-```js
-import launchWebAuthFlow from "webext-launch-web-auth-flow";
-```
-
 ### Pre-built dist
 
 You can find it under the `dist` folder, or [download from unpkg](https://unpkg.com/webext-launch-web-auth-flow/dist/).


### PR DESCRIPTION
- Apply Prettier code formatter defaults.
- Improve some variable names for better clarity;
- Add missing "await"s in async functions;
- Use object destructuring when available;
- Export ESM module instead of CJS module;