### PR TITLE
Move eslint "webextensions" environment to .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "env": { "es6": true, "node": true },
+  "env": { "es6": true, "node": true, "webextensions": true },
   "rules": {
     "no-use-before-define": [2, "nofunc"],
     "semi": [2, "always"],

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-/* eslint-env webextensions */
-
 async function createWindow(options, useTab) {
   if (browser.windows && !useTab) {
     return await browser.windows.create(options);


### PR DESCRIPTION
Now, all environments are listed in the same place, for consistency

Before, ESLint environments weren't consistent across the lib: `node` and `es6` were documented in .eslintrc.json, but `webextensions` was being used as a comment at the top of index.js.

