### PR TITLE
Add rule no-return-await

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
   "rules": {
     "no-use-before-define": [2, "nofunc"],
     "semi": [2, "always"],
-    "no-console": [2, { "allow": ["error", "warn"] }]
+    "no-console": [2, { "allow": ["error", "warn"] }],
+    "no-return-await": [2]
   },
   "extends": ["eslint:recommended"],
   "parserOptions": { "ecmaVersion": 2020 },

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 async function createWindow(options, useTab) {
   if (browser.windows && !useTab) {
-    return await browser.windows.create(options);
+    return browser.windows.create(options);
   }
   const tabOptions = {
     active: options.state !== "minimized",
@@ -16,18 +16,18 @@ async function createWindow(options, useTab) {
 
 async function updateWindow(windowId, tabId, options) {
   if (windowId) {
-    return await browser.windows.update(windowId, options);
+    return browser.windows.update(windowId, options);
   }
-  return await browser.tabs.update(tabId, {
+  return browser.tabs.update(tabId, {
     active: options.focused
   });
 }
 
 async function closeWindow(windowId, tabId) {
   if (windowId) {
-    return await browser.windows.remove(windowId);
+    return browser.windows.remove(windowId);
   }
-  return await browser.tabs.remove(tabId);
+  return browser.tabs.remove(tabId);
 }
 
 function defer() {


### PR DESCRIPTION
From [ESLint official docs](https://eslint.org/docs/latest/rules/no-return-await):

Using `return await` inside an async function keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.